### PR TITLE
Implement pagination for MangaDex API requests

### DIFF
--- a/melhoresVolumes.py
+++ b/melhoresVolumes.py
@@ -1,10 +1,26 @@
 import requests
 
-def buscar_volumes(manga_id,linguagem):
-    url = f"https://api.mangadex.org/chapter?manga={manga_id}&translatedLanguage[]={linguagem}&limit=100&order[chapter]=asc"
-    resp = requests.get(url)
-    resp.raise_for_status()
-    return resp.json()  
+def buscar_volumes(manga_id, linguagem):
+    all_data = []
+    offset = 0
+
+    while True:
+        url = (
+            f"https://api.mangadex.org/chapter?manga={manga_id}"
+            f"&translatedLanguage[]={linguagem}&limit=100&offset={offset}"
+            f"&order[chapter]=asc"
+        )
+        resp = requests.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+        all_data.extend(data.get("data", []))
+
+        total = data.get("total", 0)
+        offset += data.get("limit", 100)
+        if offset >= total or not data.get("data"):
+            break
+
+    return {"data": all_data}
 
 def selecionar_melhor_idioma_por_volume(dados_api):   
     volumes = {}

--- a/salvarviaScript.py
+++ b/salvarviaScript.py
@@ -30,11 +30,27 @@ def iniciar_driver():
     return driver
 
 # Faz requisição à API para pegar capítulos
-def buscar_capitulos(manga_id, volume,linguagem):
-    url = f"https://api.mangadex.org/chapter?manga={manga_id}&translatedLanguage[]={linguagem}&limit=100&volume[]={volume}&order[chapter]=asc"
-    resp = requests.get(url)
-    resp.raise_for_status()
-    return resp.json()["data"]
+def buscar_capitulos(manga_id, volume, linguagem):
+    all_data = []
+    offset = 0
+
+    while True:
+        url = (
+            f"https://api.mangadex.org/chapter?manga={manga_id}"
+            f"&translatedLanguage[]={linguagem}&limit=100&offset={offset}"
+            f"&volume[]={volume}&order[chapter]=asc"
+        )
+        resp = requests.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+        all_data.extend(data.get("data", []))
+
+        total = data.get("total", 0)
+        offset += data.get("limit", 100)
+        if offset >= total or not data.get("data"):
+            break
+
+    return all_data
 
 
     


### PR DESCRIPTION
## Summary
- add pagination when retrieving chapter lists and volumes
- fetch additional results in `buscar_volumes` and `buscar_capitulos`

## Testing
- `python -m py_compile mangasaveui.py config_types.py melhoresVolumes.py inputValidator.py salvarPdfnaPasta.py salvarviaScript.py trocaCapa.py old/scriptRenomearNumeros.py old/scriptsalvaimagens.py`

------
https://chatgpt.com/codex/tasks/task_e_684c21615f8083269da124a2839e3c4d