### PR TITLE
Fix PDF cover injection

### DIFF
--- a/salvarPdfnaPasta.py
+++ b/salvarPdfnaPasta.py
@@ -50,8 +50,6 @@ def criar_pdfs_para_pastas(diretorio_raiz,nome_pasta,troca_capa):
                         t.main(caminhoCapa,caminho_pdf)
                     else:
                         print('Digite um caminho valido')
-                        
-                scriptTrocaCapa()
         except Exception as e:
             print(f"Erro ao salvar PDF {caminho_pdf}: {e}")
     else:

--- a/trocaCapa.py
+++ b/trocaCapa.py
@@ -1,20 +1,27 @@
 from PyPDF2 import PdfMerger
 from PIL import Image
+import os
+
+
+TEMP_PDF = "temp_capa.pdf"
 
 
 
-def converteImagemToPdf(imagem):
+def converteImagemToPdf(imagem: str) -> None:
+    """Converte a imagem fornecida para um PDF temporário."""
     img = Image.open(imagem)
-    img.save("TEMP_PDF", "PDF", resolution=100.0)
+    img.save(TEMP_PDF, "PDF", resolution=100.0)
+    img.close()
 
 
-def juntaImagemAoPdf(pdf):
+def juntaImagemAoPdf(pdf: str) -> None:
+    """Insere o PDF temporário como capa do PDF principal."""
     merger = PdfMerger()
-    merger.append("temp_capa.pdf")
+    merger.append(TEMP_PDF)
     merger.append(pdf)
     merger.write(pdf)
     merger.close()
-    
+
     if os.path.exists(TEMP_PDF):
         os.remove(TEMP_PDF)
 


### PR DESCRIPTION
## Summary
- fix handling of temporary PDF in `trocaCapa.py`
- remove call to undefined `scriptTrocaCapa()`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68507b39333c8326b12f572e74ea3b31